### PR TITLE
Add `skippable` attribute to question sets

### DIFF
--- a/api/helpers.go
+++ b/api/helpers.go
@@ -25,3 +25,11 @@ func getNullableInt(input map[string]interface{}, key string) int {
 	}
 	return s
 }
+
+func getFalseOrBoolean(input map[string]interface{}, key string) bool {
+	givenValue := input[key]
+	if givenValue != nil {
+		return givenValue.(bool)
+	}
+	return false
+}

--- a/api/outcomeset.go
+++ b/api/outcomeset.go
@@ -232,6 +232,10 @@ func (v *v1) initOutcomeSetTypes(orgTypes organisationTypes) outcomeSetTypes {
 				Type:        graphql.String,
 				Description: "Information about the outcome set",
 			},
+			"skippable": &graphql.Field{
+				Type:        graphql.Boolean,
+				Description: "Determine if the questions of the outcome set can be skipped or not. Defaulted to false",
+			},
 			"questions": &graphql.Field{
 				Type:        graphql.NewNonNull(graphql.NewList(ret.questionInterface)),
 				Description: "Questions associated with the outcome set",
@@ -285,11 +289,16 @@ func (v *v1) getOSMutations(osTypes outcomeSetTypes) graphql.Fields {
 					Type:        graphql.String,
 					Description: "An optional description",
 				},
+				"skippable": &graphql.ArgumentConfig{
+					Type:        graphql.Boolean,
+					Description: "Determine if the questions of the outcome set can be skipped or not. Defaulted to false",
+				},
 			},
 			Resolve: userRestrictedResolver(func(p graphql.ResolveParams, u auth.User) (interface{}, error) {
 				name := p.Args["name"].(string)
 				description := getNullableString(p.Args, "description")
-				return v.db.NewOutcomeSet(name, description, u)
+				skippable := getFalseOrBoolean(p.Args, "skippable")
+				return v.db.NewOutcomeSet(name, description, skippable, u)
 			}),
 		},
 		"EditOutcomeSet": &graphql.Field{
@@ -308,12 +317,17 @@ func (v *v1) getOSMutations(osTypes outcomeSetTypes) graphql.Fields {
 					Type:        graphql.String,
 					Description: "The new description to apply to the outcomeset, if left null, any existing description will be removed",
 				},
+				"skippable": &graphql.ArgumentConfig{
+					Type:        graphql.Boolean,
+					Description: "The new  boolean value to determine if the questions of the outcome set can be skipped or not. Defaulted to false",
+				},
 			},
 			Resolve: userRestrictedResolver(func(p graphql.ResolveParams, u auth.User) (interface{}, error) {
 				id := p.Args["outcomeSetID"].(string)
 				name := p.Args["name"].(string)
 				description := getNullableString(p.Args, "description")
-				return v.db.EditOutcomeSet(id, name, description, u)
+				skippable := getFalseOrBoolean(p.Args, "skippable")
+				return v.db.EditOutcomeSet(id, name, description, skippable, u)
 			}),
 		},
 		"DeleteOutcomeSet": &graphql.Field{

--- a/data/database.go
+++ b/data/database.go
@@ -22,8 +22,8 @@ func (nf *notFound) Error() string {
 }
 
 type Base interface {
-	NewOutcomeSet(name, description string, u auth.User) (impact.OutcomeSet, error)
-	EditOutcomeSet(id, name, description string, u auth.User) (impact.OutcomeSet, error)
+	NewOutcomeSet(name, description string, skippable bool, u auth.User) (impact.OutcomeSet, error)
+	EditOutcomeSet(id, name, description string, skippable bool, u auth.User) (impact.OutcomeSet, error)
 	GetOutcomeSet(id string, u auth.User) (impact.OutcomeSet, error)
 	GetOutcomeSets(u auth.User) ([]impact.OutcomeSet, error)
 	DeleteOutcomeSet(id string, u auth.User) error

--- a/data/mongo/outcomeset.go
+++ b/data/mongo/outcomeset.go
@@ -7,7 +7,7 @@ import (
 	"github.com/impactasaurus/server/auth"
 	"github.com/impactasaurus/server/data"
 	uuid "github.com/satori/go.uuid"
-	"gopkg.in/mgo.v2"
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -53,7 +53,7 @@ func (m *mongo) GetOutcomeSets(u auth.User) ([]impact.OutcomeSet, error) {
 	return results, err
 }
 
-func (m *mongo) NewOutcomeSet(name, description string, u auth.User) (impact.OutcomeSet, error) {
+func (m *mongo) NewOutcomeSet(name, description string, skippable bool, u auth.User) (impact.OutcomeSet, error) {
 	userOrg, err := u.Organisation()
 	if err != nil {
 		return impact.OutcomeSet{}, err
@@ -82,6 +82,7 @@ func (m *mongo) NewOutcomeSet(name, description string, u auth.User) (impact.Out
 		Description:    description,
 		Name:           name,
 		OrganisationID: userOrg,
+		Skippable:      skippable,
 	}
 	if err := col.Insert(newOS); err != nil {
 		return impact.OutcomeSet{}, err
@@ -89,7 +90,7 @@ func (m *mongo) NewOutcomeSet(name, description string, u auth.User) (impact.Out
 	return m.GetOutcomeSet(id.String(), u)
 }
 
-func (m *mongo) EditOutcomeSet(id, name, description string, u auth.User) (impact.OutcomeSet, error) {
+func (m *mongo) EditOutcomeSet(id, name, description string, skippable bool, u auth.User) (impact.OutcomeSet, error) {
 	userOrg, err := u.Organisation()
 	if err != nil {
 		return impact.OutcomeSet{}, err
@@ -105,6 +106,7 @@ func (m *mongo) EditOutcomeSet(id, name, description string, u auth.User) (impac
 		"$set": bson.M{
 			"name":        name,
 			"description": description,
+			"skippable":   skippable,
 		},
 	}); err != nil {
 		return impact.OutcomeSet{}, err

--- a/outcomeset.go
+++ b/outcomeset.go
@@ -36,6 +36,7 @@ type OutcomeSet struct {
 	Questions      []Question `json:"questions"`
 	Categories     []Category `json:"categories"`
 	Deleted        bool       `json:"deleted"`
+	Skippable      bool       `json:"skippable"`
 }
 
 func (os *OutcomeSet) GetCategory(catID string) *Category {


### PR DESCRIPTION
This change adds the skippable attribute to outcome set objects, which
defaults to `false`. This will allow users to skip questions for that
question set. Close #30